### PR TITLE
Add namespace for keepAlive() ping when not using auth credentials

### DIFF
--- a/src/robomongo/core/mongodb/MongoWorker.cpp
+++ b/src/robomongo/core/mongodb/MongoWorker.cpp
@@ -421,7 +421,12 @@ void MongoWorker::keepAlive()
             mongo::BSONObjBuilder command;
             command.append("ping", 1);
             mongo::BSONObj result;
-            _dbclient->runCommand(_authDatabase.toStdString(), command.obj(), result);
+
+            if (_authDatabase.isEmpty()) {
+                _dbclient->runCommand("admin", command.obj(), result);
+            } else {
+                _dbclient->runCommand(_authDatabase.toStdString(), command.obj(), result);
+            }
         }
 
         if (_scriptEngine) {


### PR DESCRIPTION
If you haven't authenticated to a database, the keepAlive() ping was passing an empty namespace and logging assertions once a minute for every connection:

Sun Mar 24 10:54:06.641 [conn11] assertion 16256 Invalid ns [.$cmd] ns:.$cmd query:{ ping: 1 }
