### PR TITLE
OS X: make connect/save/add buttons default in dialogs

### DIFF
--- a/src/robomongo/gui/dialogs/ConnectionDialog.cpp
+++ b/src/robomongo/gui/dialogs/ConnectionDialog.cpp
@@ -37,6 +37,7 @@ ConnectionDialog::ConnectionDialog(ConnectionSettings *connection) : QDialog(),
     bottomLayout->addWidget(testButton, 1, Qt::AlignLeft);
 
 #if defined(Q_OS_MAC)
+    saveButton->setDefault(true);
     bottomLayout->addWidget(cancelButton, 1, Qt::AlignRight);
     bottomLayout->addWidget(saveButton);
 #else

--- a/src/robomongo/gui/dialogs/ConnectionsDialog.cpp
+++ b/src/robomongo/gui/dialogs/ConnectionsDialog.cpp
@@ -90,6 +90,7 @@ ConnectionsDialog::ConnectionsDialog(SettingsManager *settingsManager) : QDialog
 
     QHBoxLayout *bottomLayout = new QHBoxLayout;
 #if defined(Q_OS_MAC)
+    connectButton->setDefault(true);
     bottomLayout->addWidget(cancelButton, 1, Qt::AlignRight);
     bottomLayout->addWidget(connectButton);
 #else

--- a/src/robomongo/gui/dialogs/CreateDatabaseDialog.cpp
+++ b/src/robomongo/gui/dialogs/CreateDatabaseDialog.cpp
@@ -34,6 +34,7 @@ CreateDatabaseDialog::CreateDatabaseDialog(const QString &serverName, const QStr
     hlayout->addStretch(1);
 
 #if defined(Q_OS_MAC)
+    _okButton->setDefault(true);
     hlayout->addWidget(cancelButton, 0, Qt::AlignRight);
     hlayout->addWidget(_okButton, 0, Qt::AlignRight);
 #else

--- a/src/robomongo/gui/dialogs/CreateUserDialog.cpp
+++ b/src/robomongo/gui/dialogs/CreateUserDialog.cpp
@@ -44,6 +44,7 @@ CreateUserDialog::CreateUserDialog(const QString &serverName,
     hlayout->addStretch(1);
 
 #if defined(Q_OS_MAC)
+    _okButton->setDefault(true);
     hlayout->addWidget(cancelButton, 0, Qt::AlignRight);
     hlayout->addWidget(_okButton, 0, Qt::AlignRight);
 #else

--- a/src/robomongo/gui/dialogs/DocumentTextEditor.cpp
+++ b/src/robomongo/gui/dialogs/DocumentTextEditor.cpp
@@ -57,6 +57,7 @@ DocumentTextEditor::DocumentTextEditor(const QString &server, const QString &dat
     bottomlayout->addStretch(1);
 
 #if defined(Q_OS_MAC)
+    save->setDefault(true);
     bottomlayout->addWidget(cancel, 0, Qt::AlignRight);
     bottomlayout->addWidget(save, 0, Qt::AlignRight);
 #else

--- a/src/robomongo/gui/dialogs/FunctionTextEditor.cpp
+++ b/src/robomongo/gui/dialogs/FunctionTextEditor.cpp
@@ -53,6 +53,7 @@ FunctionTextEditor::FunctionTextEditor(const QString &server, const QString &dat
     bottomlayout->addStretch(1);
 
 #if defined(Q_OS_MAC)
+    save->setDefault(true);
     bottomlayout->addWidget(cancel, 0, Qt::AlignRight);
     bottomlayout->addWidget(save, 0, Qt::AlignRight);
 #else


### PR DESCRIPTION
Focus is set on connect/save/add buttons and you can just press enter to submit
