### PR TITLE
Persist the view mode setting

### DIFF
--- a/src/robomongo/core/settings/SettingsManager.cpp
+++ b/src/robomongo/core/settings/SettingsManager.cpp
@@ -99,7 +99,14 @@ void SettingsManager::loadFromMap(QVariantMap &map)
 
     _uuidEncoding = (UUIDEncoding) encoding;
 
-    // 3. Load connections
+    // 3. Load view mode
+    int viewMode = map.value("viewMode").toInt();
+    if (viewMode > 2 || encoding < 0)
+        viewMode = 0;
+
+    _viewMode = (ViewMode) viewMode;
+
+    // 4. Load connections
     _connections.clear();
 
     QVariantList list = map.value("connections").toList();
@@ -123,7 +130,10 @@ QVariantMap SettingsManager::convertToMap() const
     // 2. Save UUID encoding
     map.insert("uuidEncoding", _uuidEncoding);
 
-    // 3. Save connections
+    // 3. Save view mode
+    map.insert("viewMode", _viewMode);
+
+    // 4. Save connections
     QVariantList list;
 
     foreach(ConnectionSettings *record, _connections) {

--- a/src/robomongo/core/settings/SettingsManager.h
+++ b/src/robomongo/core/settings/SettingsManager.h
@@ -4,6 +4,7 @@
 #include <QObject>
 
 #include "robomongo/core/Core.h"
+#include "robomongo/gui/ViewMode.h"
 #include "robomongo/core/settings/ConnectionSettings.h"
 
 namespace Robomongo
@@ -77,6 +78,9 @@ namespace Robomongo
         void setUuidEncoding(UUIDEncoding encoding) { _uuidEncoding = encoding; }
         UUIDEncoding uuidEncoding() { return _uuidEncoding; }
 
+        void setViewMode(ViewMode viewMode) { _viewMode = viewMode; }
+        ViewMode viewMode() { return _viewMode; }
+
     signals:
         void connectionAdded(ConnectionSettings *connection);
         void connectionUpdated(ConnectionSettings *connection);
@@ -114,6 +118,11 @@ namespace Robomongo
          * @brief UUID encoding
          */
         UUIDEncoding _uuidEncoding;
+
+        /**
+         * @brief view mode
+         */
+        ViewMode _viewMode;
 
         /**
          * @brief List of connections

--- a/src/robomongo/gui/MainWindow.cpp
+++ b/src/robomongo/gui/MainWindow.cpp
@@ -25,7 +25,7 @@ MainWindow::MainWindow() : QMainWindow(),
     _bus(AppRegistry::instance().bus()),
     _workArea(NULL),
     _connectionsMenu(NULL),
-    _viewMode(Custom)
+    _viewMode(Text)
 {
     GuiRegistry::instance().setMainWindow(this);
 
@@ -92,20 +92,25 @@ MainWindow::MainWindow() : QMainWindow(),
     _orientationAction->setToolTip("Toggle orientation of results view <b>(F10)</b>");
     connect(_orientationAction, SIGNAL(triggered()), this, SLOT(toggleOrientation()));
 
+    // read view mode setting
+    _viewMode = _settingsManager->viewMode();
+
     // Text mode action
     QAction *textModeAction = new QAction("&Text Mode", this);
     textModeAction->setShortcut(Qt::Key_F4);
     textModeAction->setIcon(GuiRegistry::instance().textHighlightedIcon());
     textModeAction->setToolTip("Show current tab in text mode, and make this mode default for all subsequent queries <b>(F4)</b>");
     textModeAction->setCheckable(true);
+    textModeAction->setChecked(_viewMode == Text);
     connect(textModeAction, SIGNAL(triggered()), this, SLOT(enterTextMode()));
 
-    // Text mode action
+    // Tree mode action
     QAction *treeModeAction = new QAction("&Tree Mode", this);
     treeModeAction->setShortcut(Qt::Key_F3);
     treeModeAction->setIcon(GuiRegistry::instance().treeHighlightedIcon());
     treeModeAction->setToolTip("Show current tab in tree mode, and make this mode default for all subsequent queries <b>(F3)</b>");
     treeModeAction->setCheckable(true);
+    treeModeAction->setChecked(_viewMode == Tree);
     connect(treeModeAction, SIGNAL(triggered()), this, SLOT(enterTreeMode()));
 
     // Custom mode action
@@ -114,7 +119,7 @@ MainWindow::MainWindow() : QMainWindow(),
     customModeAction->setIcon(GuiRegistry::instance().customHighlightedIcon());
     customModeAction->setToolTip("Show current tab in custom mode if possible, and make this mode default for all subsequent queries <b>(F2)</b>");
     customModeAction->setCheckable(true);
-    customModeAction->setChecked(true);
+    customModeAction->setChecked(_viewMode == Custom);
     connect(customModeAction, SIGNAL(triggered()), this, SLOT(enterCustomMode()));
 
     QActionGroup *modeGroup = new QActionGroup(this);
@@ -333,6 +338,7 @@ void MainWindow::toggleOrientation()
 void MainWindow::enterTextMode()
 {
     _viewMode = Text;
+    saveViewMode();
     if (_workArea)
         _workArea->enterTextMode();
 }
@@ -340,6 +346,7 @@ void MainWindow::enterTextMode()
 void MainWindow::enterTreeMode()
 {
     _viewMode = Tree;
+    saveViewMode();
     if (_workArea)
         _workArea->enterTreeMode();
 }
@@ -347,8 +354,15 @@ void MainWindow::enterTreeMode()
 void MainWindow::enterCustomMode()
 {
     _viewMode = Custom;
+    saveViewMode();
     if (_workArea)
         _workArea->enterCustomMode();
+}
+
+void MainWindow::saveViewMode()
+{
+    _settingsManager->setViewMode(_viewMode);
+    _settingsManager->save();
 }
 
 void MainWindow::executeScript()

--- a/src/robomongo/gui/MainWindow.h
+++ b/src/robomongo/gui/MainWindow.h
@@ -36,6 +36,7 @@ namespace Robomongo
         void enterTextMode();
         void enterTreeMode();
         void enterCustomMode();
+        void saveViewMode();
         void executeScript();
         void stopScript();
         void toggleFullScreen2();

--- a/src/robomongo/gui/ViewMode.h
+++ b/src/robomongo/gui/ViewMode.h
@@ -4,8 +4,8 @@ namespace Robomongo
 {
     enum ViewMode
     {
-        Text,
-        Tree,
-        Custom
+        Text = 0,
+        Tree = 1,
+        Custom = 2
     };
 }


### PR DESCRIPTION
This change persists the view mode (Custom, Tree or Text). The setting will be saved whenever it is changed by selecting a new mode from the menu on the main window. 

It's a small change, but one that makes Robomongo much more pleasurable to use if you routinely use a view mode other than the default.

The change follows the pattern used by the already persistant LegacyUUIDEncoding setting.
