### PR TITLE
fix url in about dialog

### DIFF
--- a/src/robomongo/gui/dialogs/AboutDialog.cpp
+++ b/src/robomongo/gui/dialogs/AboutDialog.cpp
@@ -15,7 +15,7 @@ namespace
         "Shell-centric MongoDB management tool."
         "<br/>"
         "<br/>"
-        "Visit "PROJECT_NAME_TITLE" website: <a href=\""PROJECT_DOMAIN"\">"PROJECT_DOMAIN"</a> <br/>"
+        "Visit "PROJECT_NAME_TITLE" website: <a href=\"http://"PROJECT_DOMAIN"\">"PROJECT_DOMAIN"</a> <br/>"
         "<br/>"
         "<a href=\"https://"PROJECT_GITHUB_FORK"\">Fork</a> project or <a href=\""PROJECT_GITHUB_ISSUES"\">submit</a> issues/proposals on GitHub.  <br/>"
         "<br/>"


### PR DESCRIPTION
In Mac OS X link "Visit Robomongo website:" does not work.
