### PR TITLE
Fix #500: TTL index should allow expiry of 0 seconds

### DIFF
--- a/src/robomongo/core/events/MongoEventsInfo.h
+++ b/src/robomongo/core/events/MongoEventsInfo.h
@@ -14,7 +14,7 @@ namespace Robomongo
             bool isBackGround = false,
             bool isDropDuplicates = false,
             bool isSparce = false,
-            int expireAfter = 0,
+            int expireAfter = -1,
             const std::string &defaultLanguage = std::string(),
             const std::string &languageOverride = std::string(),
             const std::string &textWeights = std::string());

--- a/src/robomongo/gui/widgets/explorer/EditIndexDialog.cpp
+++ b/src/robomongo/gui/widgets/explorer/EditIndexDialog.cpp
@@ -199,7 +199,7 @@ namespace Robomongo
 
         QCheckBox *expireCheckBox = new QCheckBox(tr("Expire after"));
         expireCheckBox->setChecked(false);
-        if (_info._ttl > 0) {
+        if (_info._ttl >= 0) {
             expireCheckBox->setChecked(true);
             _expireAfterLineEdit->setText(QString("%1").arg(_info._ttl));
         }


### PR DESCRIPTION
Docs example:
http://docs.mongodb.org/manual/tutorial/expire-data/#expire-documents-at-a-certain-clock-time
