### PR TITLE
Fix #519: Full screen mode not working on OS X

### DIFF
--- a/shortcuts.txt
+++ b/shortcuts.txt
@@ -59,7 +59,7 @@ Robomongo shortcut key reference
       Toggle result orientation (between vertical and horizontal) for two or
       more result panes.
 
-   F11
+   Ctrl+F11
       Toggle fullscreen mode.
 
    F12
@@ -118,3 +118,6 @@ Robomongo shortcut key reference
    F10
       Toggle result orientation (between vertical and horizontal) for two or
       more result panes.
+
+   Cmd+F11
+      Toggle fullscreen mode.

--- a/src/robomongo/gui/MainWindow.cpp
+++ b/src/robomongo/gui/MainWindow.cpp
@@ -220,7 +220,7 @@ namespace Robomongo
 
         // Full screen action
         QAction *fullScreenAction = new QAction("&Full Screen", this);
-        fullScreenAction->setShortcut(Qt::Key_F11);
+        fullScreenAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_F11));
         fullScreenAction->setVisible(true);
         VERIFY(connect(fullScreenAction, SIGNAL(triggered()), this, SLOT(toggleFullScreen2())));
 


### PR DESCRIPTION
- changed fullscreen shortcut to Cmd/Ctrl+F11
