### PR TITLE
Fix #449: Add line numbers to JSON editing window (OS X)

### DIFF
--- a/shortcuts.txt
+++ b/shortcuts.txt
@@ -59,8 +59,11 @@ Robomongo shortcut key reference
       Toggle result orientation (between vertical and horizontal) for two or
       more result panes.
 
-   Ctrl+F11
+   F11
       Toggle fullscreen mode.
+
+   Ctrl+F11
+      Toggle line numbers in Javascript editing views
 
    F12
       Opens connection popup menu.
@@ -121,3 +124,6 @@ Robomongo shortcut key reference
 
    Cmd+F11
       Toggle fullscreen mode.
+
+   Ctrl+F11
+      Toggle line numbers in Javascript editing views

--- a/src/robomongo/gui/MainWindow.cpp
+++ b/src/robomongo/gui/MainWindow.cpp
@@ -220,7 +220,11 @@ namespace Robomongo
 
         // Full screen action
         QAction *fullScreenAction = new QAction("&Full Screen", this);
+    #if !defined(Q_OS_MAC)
+        fullScreenAction->setShortcut(Qt::Key_F11);
+    #else
         fullScreenAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_F11));
+    #endif
         fullScreenAction->setVisible(true);
         VERIFY(connect(fullScreenAction, SIGNAL(triggered()), this, SLOT(toggleFullScreen2())));
 


### PR DESCRIPTION
- Line numbers in JSON views can now be toggled with Ctrl+F11 on OS X
