### PR TITLE
Fix #544: Space after document causes validation error

### DIFF
--- a/src/robomongo/gui/dialogs/DocumentTextEditor.cpp
+++ b/src/robomongo/gui/dialogs/DocumentTextEditor.cpp
@@ -83,7 +83,7 @@ namespace Robomongo
 
     QString DocumentTextEditor::jsonText() const
     {
-        return _queryText->sciScintilla()->text();
+        return _queryText->sciScintilla()->text().trimmed();
     }
 
     void DocumentTextEditor::setCursorPosition(int line, int column)


### PR DESCRIPTION
- ignore leading/trailing whitespace
