### PR TITLE
Fix #421: Consistent numbering for tree/table/text view items

### DIFF
--- a/src/robomongo/gui/widgets/workarea/JsonPrepareThread.cpp
+++ b/src/robomongo/gui/widgets/workarea/JsonPrepareThread.cpp
@@ -23,13 +23,13 @@ namespace Robomongo
 
     void JsonPrepareThread::run()
     {
-        int position = 0;
+        int position = 1; // 1-based numbering to match tree & table views
         for(std::vector<MongoDocumentPtr>::const_iterator it = _bsonObjects.begin();it!=_bsonObjects.end();++it)
         {
             MongoDocumentPtr doc = *it;
             mongo::StringBuilder sb;
-            if (position == 0)
-                sb << "/* 0 */\n";
+            if (position == 1)
+                sb << "/* 1 */\n";
             else
                 sb << "\n\n/* " << position << " */\n";
 


### PR DESCRIPTION
Not sure if 1-based or 0-based makes more sense; conceptually result lists should probably be 1-based, but JS arrays happen to be 0-based.

For consistency, have changed the text view to be 1-based to match the table+tree item numbering.
