### PR TITLE
Set first column width in BsonTreeView by content

### DIFF
--- a/src/robomongo/gui/widgets/workarea/BsonTreeView.cpp
+++ b/src/robomongo/gui/widgets/workarea/BsonTreeView.cpp
@@ -79,6 +79,9 @@ namespace Robomongo
     {
         BaseClass::resizeEvent(event);
         header()->resizeSections(QHeaderView::ResizeToContents);
+        int eKeyWidth = header()->sectionSize(BsonTreeItem::eKey);
+        header()->resizeSections(QHeaderView::Stretch);
+        header()->resizeSection(BsonTreeItem::eKey, width);
     }
 
     void BsonTreeView::keyPressEvent(QKeyEvent *event)

--- a/src/robomongo/gui/widgets/workarea/BsonTreeView.cpp
+++ b/src/robomongo/gui/widgets/workarea/BsonTreeView.cpp
@@ -78,7 +78,7 @@ namespace Robomongo
     void BsonTreeView::resizeEvent(QResizeEvent *event)
     {
         BaseClass::resizeEvent(event);
-        header()->resizeSections(QHeaderView::Stretch);
+        header()->resizeSections(QHeaderView::ResizeToContents);
     }
 
     void BsonTreeView::keyPressEvent(QKeyEvent *event)


### PR DESCRIPTION
Hi, this pull request fixes my little pain.  On my macbook pro 13" where is no enough space on screen i see something like this 

![screen shot 2016-09-20 at 1 06 59 am](https://cloud.githubusercontent.com/assets/3436529/18650707/2975d104-7ecf-11e6-8328-708a4cefa39a.png)
Last symbols in id always hidden, even if i resize column after refresh data it go back and hide symbols, i make first column width dependent from content and now it's always right width.

Related to  #913 

Tested 
OS X: 10.11.4
QT: mac x64 clang 5.7.0
Scons: 2.5.0
Cmake: 3.6.2-Darwin-x86_64
