### PR TITLE
New option into context menu that copies identifier from ObjectId

### DIFF
--- a/src/robomongo/core/domain/Notifier.cpp
+++ b/src/robomongo/core/domain/Notifier.cpp
@@ -132,6 +132,9 @@ namespace Robomongo
         _copyTimestampAction = new QAction("Copy Timestamp from ObjectId", wid);
         VERIFY(connect(_copyTimestampAction, SIGNAL(triggered()), SLOT(onCopyTimestamp())));
 
+        _copyIdentifierAction = new QAction("Copy Identifier from ObjectId", wid);
+        VERIFY(connect(_copyIdentifierAction, SIGNAL(triggered()), SLOT(onCopyIdentifier())));
+
         _copyJsonAction = new QAction("Copy JSON", wid);
         VERIFY(connect(_copyJsonAction, SIGNAL(triggered()), SLOT(onCopyJson())));        
     }
@@ -474,6 +477,25 @@ namespace Robomongo
         else {
             clipboard->setText("Error extracting ISODate()");
         }
+    }
+
+    void Notifier::onCopyIdentifier()
+    {
+        QModelIndex selectedInd = _observer->selectedIndex();
+        if (!selectedInd.isValid())
+            return;
+
+        BsonTreeItem *documentItem = QtUtils::item<BsonTreeItem*>(selectedInd);
+        if (!documentItem)
+            return;
+
+        if (!detail::isObjectIdType(documentItem))
+            return;
+
+        QString identifier = documentItem->value().mid(10, 24);
+
+        QClipboard *clipboard = QApplication::clipboard();
+        clipboard->setText(identifier);
     }
 
      void Notifier::onCopyJson()

--- a/src/robomongo/core/domain/Notifier.cpp
+++ b/src/robomongo/core/domain/Notifier.cpp
@@ -171,6 +171,7 @@ namespace Robomongo
             menu->addAction(_copyValuePathAction);
 
         if (onItem && isObjectId) menu->addAction(_copyTimestampAction);
+        if (onItem && isObjectId) menu->addAction(_copyIdentifierAction);
         if (onItem && isDocument) menu->addAction(_copyJsonAction);
         if (onItem && isEditable) menu->addSeparator();
         if (onItem && isEditable) menu->addAction(_deleteDocumentAction);

--- a/src/robomongo/core/domain/Notifier.h
+++ b/src/robomongo/core/domain/Notifier.h
@@ -56,6 +56,7 @@ namespace Robomongo
         void onInsertDocument();
         void onCopyDocument();
         void onCopyTimestamp();
+        void onCopyIdentifier();
         void onCopyJson();
         void handle(InsertDocumentResponse *event);
         void handle(RemoveDocumentResponse *event);


### PR DESCRIPTION
This pull request adds a new option `Copy identifier from ObjectId` to the context menu when you right click on a field of type `ObjectId`.

![image](https://user-images.githubusercontent.com/16188556/28967144-162d1d6e-791a-11e7-9d86-3d4b5353ec14.png)

This option copies into the clipboard the hexadecimal representation of the ObjectId as String.

For example, if you  right click `ObjectId("58aeb4e2406f771000890dde")` and choose this option, the application would copy 58aeb4e2406f771000890dde into the clipboard.