### PR TITLE
#638 Check for DB error response before handling

### DIFF
--- a/src/robomongo/core/mongodb/MongoClient.cpp
+++ b/src/robomongo/core/mongodb/MongoClient.cpp
@@ -90,6 +90,10 @@ namespace Robomongo
         // Cursor may be NULL, it means we have connectivity problem
         if (!cursor)
             throw mongo::DBException("Network error while attempting to load list of users", 0);
+        
+        std::string errorStr = _dbclient->getLastError();
+        if (!errorStr.empty())
+            throw mongo::DBException(errorStr, 0);
 
         float ver = getVersion();
         while (cursor->more()) {


### PR DESCRIPTION
The code is unchecked, sorry for this. I can't build project locally.

It seems, what client is not checked for the error response from MongoDB.
I reproduced #638 by the direct request and get error
`db.system.users.find()`

```
Error: error: {
	"ok" : 0,
	"errmsg" : "not authorized on mydb to execute command { find: \"system.users\", filter: {} }",
	"code" : 13,
	"codeName" : "Unauthorized"
}
```