### PR TITLE
Add support for writing log file.

### DIFF
--- a/src/robomongo/core/settings/SettingsManager.cpp
+++ b/src/robomongo/core/settings/SettingsManager.cpp
@@ -90,6 +90,7 @@ namespace Robomongo
         _autocompletionMode(AutocompleteAll),
         _loadMongoRcJs(false),
         _minimizeToTray(false),
+        _writeLogFile(true),
         _lineNumbers(false),
         _disableConnectionShortcuts(false),
         _batchSize(50),
@@ -204,6 +205,7 @@ namespace Robomongo
         _autoExpand = map.contains("autoExpand") ? map.value("autoExpand").toBool() : true;
         _autoExec = map.contains("autoExec") ? map.value("autoExec").toBool() : true;
         _minimizeToTray = map.contains("minimizeToTray") ? map.value("minimizeToTray").toBool() : false;
+        _writeLogFile = map.contains("writeLogFile") ? map.value("writeLogFile").toBool() : true;
         _lineNumbers = map.contains("lineNumbers") ? map.value("lineNumbers").toBool() : false;
         _imported = map.contains("imported") ? map.value("imported").toBool() : false;
         _programExitedNormally = map.contains("programExitedNormally") ? 
@@ -390,6 +392,7 @@ namespace Robomongo
 
         map.insert("autoExec", _autoExec);
         map.insert("minimizeToTray", _minimizeToTray);
+        map.insert("writeLogFile", _writeLogFile);
         map.insert("toolbars", _toolbars);
         map.insert("imported", _imported);
         map.insert("anonymousID", _anonymousID);

--- a/src/robomongo/core/settings/SettingsManager.h
+++ b/src/robomongo/core/settings/SettingsManager.h
@@ -148,6 +148,7 @@ namespace Robomongo
 
         void setMinimizeToTray(bool isMinimizingToTray) { _minimizeToTray = isMinimizingToTray; }
         bool minimizeToTray() const { return _minimizeToTray; }
+        bool writeLogFile() const { return _writeLogFile; }
 
         void setLineNumbers(bool showLineNumbers) { _lineNumbers = showLineNumbers; }
         bool lineNumbers() const { return _lineNumbers; }
@@ -245,6 +246,7 @@ namespace Robomongo
         bool _autoExpand;
         bool _autoExec;
         bool _minimizeToTray;
+        bool _writeLogFile;
         bool _lineNumbers;
         bool _disableConnectionShortcuts;
         bool _programExitedNormally = true;


### PR DESCRIPTION
Writes robo3t log file into the same directory where settings are stored.
Log file has the same contents as log tab shown in the app and contains
history of all commands executed.

Enabled by default, can be disabled by changing: "writeLogFile": false in the settings.

Should also fix #49 and #1116 