### PR TITLE
"Create index in background" true by default

### DIFF
--- a/src/robomongo/core/events/MongoEventsInfo.h
+++ b/src/robomongo/core/events/MongoEventsInfo.h
@@ -11,7 +11,7 @@ namespace Robomongo
             const std::string &name = std::string(),
             const std::string &request = std::string(),
             bool isUnique = false,
-            bool isBackGround = false,
+            bool isBackGround = true,
             bool isDropDuplicates = false,
             bool isSparce = false,
             int expireAfter = -1,


### PR DESCRIPTION
Following the suggestion made on the issue #1656, this code changes the default option value to true when creating new indexes.